### PR TITLE
if vendor script detects  modified files, show diff

### DIFF
--- a/script/validate/vendor
+++ b/script/validate/vendor
@@ -37,6 +37,7 @@ DIFF_PATH="vendor/ go.mod go.sum"
 #
 # shellcheck disable=SC2046
 DIFF=$(git status --porcelain -- $DIFF_PATH)
+DIFF_CONTENT=$(git diff -- $DIFF_PATH)
 
 if [ "$DIFF" ]; then
     echo
@@ -44,6 +45,8 @@ if [ "$DIFF" ]; then
     echo
     echo "$DIFF"
     echo
+    echo "Content of the diff:"
+    echo "$DIFF_CONTENT"
     exit 1
 else
     echo "$DIFF_PATH is correct"


### PR DESCRIPTION
Showing the content of the diff helps debugging.

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>

notes: Sometimes project check fails in github builds indicating file modifications not in commit. But in local builds, those files are not shown modified outside of the commit. Being able to check the diff content in build artifact's raw content will greatly reduce time to debug such issues.
