### PR TITLE
Support specifying `go-mod-tidy-flags`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   working-directory:
     required: true
     description: Go project path to run checks in
+  go-mod-tidy-flags:
+    required: false
+    description: go mod tidy flags, such as -compat=1.17
 runs:
   using: composite
   steps:
@@ -87,6 +90,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
+        export GO_MOD_TIDY_FLAGS="${{ inputs.go-mod-tidy-flags }}"
         echo "::group::🚀 Vendor directory"
         ${{ github.action_path }}/script/validate/vendor
         echo "::endgroup::"

--- a/script/validate/vendor
+++ b/script/validate/vendor
@@ -21,7 +21,9 @@ if [ -f vendor.conf ]; then
   rm -rf vendor/
   vndr |& grep -v -i clone
 elif [ -f go.mod ]; then
-  go mod tidy
+  : "${GO_MOD_TIDY_FLAGS:=}"
+  # shellcheck disable=SC2086
+  go mod tidy $GO_MOD_TIDY_FLAGS
   if [ -d vendor ]; then
     rm -rf vendor/
     go mod vendor


### PR DESCRIPTION
For https://github.com/containerd/nerdctl/pull/718#issuecomment-1019089781


```
  To proceed despite packages unresolved in go 1.16:
  	go mod tidy -e
  If reproducibility with go 1.16 is not needed:
  	go mod tidy -compat=1.17
  For other options, see:
  	https://golang.org/doc/modules/pruning
```

cc @Junnplus