### PR TITLE
replace `go get` with `go install`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,12 +55,12 @@ runs:
     - name: Install dependencies
       shell: bash
       env:
-        GO111MODULE: off
+        GO111MODULE: on
       run: |
         echo "::group::🚧 Get dependencies"
-        go get -u -v github.com/vbatts/git-validation
-        go get -u -v github.com/kunalkushwaha/ltag
-        go get -u -v github.com/LK4D4/vndr
+        go install -v github.com/vbatts/git-validation@latest
+        go install -v github.com/kunalkushwaha/ltag@latest
+        go install -v github.com/LK4D4/vndr@latest
         echo "::endgroup::"
 
     - name: DCO Checks

--- a/script/validate/dco
+++ b/script/validate/dco
@@ -19,7 +19,7 @@ set -eu -o pipefail
 
 if ! command -v git-validation; then
     >&2 echo "ERROR: git-validation not found. Install with:"
-    >&2 echo "    go get -u github.com/vbatts/git-validation"
+    >&2 echo "    go install github.com/vbatts/git-validation@latest"
     exit 1
 fi
 

--- a/script/validate/fileheader
+++ b/script/validate/fileheader
@@ -19,7 +19,7 @@ set -eu -o pipefail
 
 if ! command -v ltag; then
     >&2 echo "ERROR: ltag not found. Install with:"
-    >&2 echo "    go get -u github.com/kunalkushwaha/ltag"
+    >&2 echo "    go install github.com/kunalkushwaha/ltag@latest"
     exit 1
 fi
 


### PR DESCRIPTION
The latest version of golang.org/x/sys requires Go 1.17 and cannot be compiled with older versions of Go.  github.com/vbatts/git-validation imports golang.org/x/sys and specifies a compatible version of golang.org/x/sys in its go.mod, but using `go get -u` overrides the version.  Use `go install` instead, which will respect the version specified in git-validation's go.mod.

See also https://github.com/vbatts/git-validation/issues/56 and https://github.com/opencontainers/distribution-spec/issues/343.