### PR TITLE
Run project-checks@v1.1.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  project:
+    name: Project Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - uses: ./


### PR DESCRIPTION
### Issue
The project checks package helps maintainers spot check pull requests for common checks across the containerd organization. We want to run these same checks on the project-checks package to validate contributions to it as well.

### Description
This change is to run project-checks@v1.1.0 in CI.

Note: this is not testing the changes made to project-checks in CI.