### PR TITLE
kunalkushwaha/ltag -> containerd/ltag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
       run: |
         echo "::group::🚧 Get dependencies"
         go install -v github.com/vbatts/git-validation@latest
-        go install -v github.com/kunalkushwaha/ltag@latest
+        go install -v github.com/containerd/ltag@latest
         echo "::endgroup::"
 
     - name: DCO Checks

--- a/script/validate/fileheader
+++ b/script/validate/fileheader
@@ -19,7 +19,7 @@ set -eu -o pipefail
 
 if ! command -v ltag; then
     >&2 echo "ERROR: ltag not found. Install with:"
-    >&2 echo "    go install github.com/kunalkushwaha/ltag@latest"
+    >&2 echo "    go install github.com/containerd/ltag@latest"
     exit 1
 fi
 


### PR DESCRIPTION
`go install github.com/kunalkushwaha/ltag@latest` no longer works, even for ltag v0.2.x.

```
go: downloading github.com/kunalkushwaha/ltag v0.3.0
go: github.com/kunalkushwaha/ltag@latest: version constraints conflict:
	github.com/kunalkushwaha/ltag@v0.3.0: parsing go.mod:
	module declares its path as: github.com/containerd/ltag
	        but was required as: github.com/kunalkushwaha/ltag
```

Caused by containerd/ltag#19