### PR TITLE
Fix go-licenses argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
     - name: Check licenses
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: go-licenses check --include_tests  ${{ github.workspace }}/... --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
+      run: go-licenses check --include_tests ./... --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
 
 
     - name: Validate file headers


### PR DESCRIPTION
See https://github.com/containerd/containerd/pull/11473#issuecomment-2696374120

```
Run go-licenses check --include_tests  /home/runner/work/containerd/containerd/... --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
F0304 06:39:40.118211    4835 main.go:77] errors for ["/home/runner/work/containerd/containerd/..."]:
/home/runner/work/containerd/containerd/...: -: pattern /home/runner/work/containerd/containerd/...: directory prefix ../../../.. does not contain main module or its selected dependencies
```